### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ MACHINE=icicle-kit-es bitbake mpfs-dev-cli
 Using Yocto bitbake command and setting the initramfs configuration file (conf/initramfs.conf) and the mpfs-initramfs-image
 
 ```bash
-MACHINE=icicle-kit-es -R conf/initramfs.conf bitbake mpfs-initramfs-image
+MACHINE=icicle-kit-es bitbake mpfs-initramfs-image -R conf/initramfs.conf
 ```
 
 The image generated from the command above can be used to boot Linux with a RAM-based root filesystem from the eMMC, an SD card, or an external QSPI flash memory device.


### PR DESCRIPTION
This is a change in the documentation only.
There is an error in this command.
"-R conf/initramfs.conf " should be at the end of the line Or else it gives the error -R command not found. 
It expects the bitbake command

# Description

The command shown gives an error : -R command not found
"-R conf/initramfs.conf " is an argument for the bitbake command

Fixes # (issue)

put the "-R conf/initramfs.conf " at the end of the line

Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?

Just ran the command

**Test Configuration**:
* Follow the instruction until this line

# Checklist:

NA documentation change only.

- [ ] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
