### PR TITLE
Improve UDP speed on PolarFire SoC

### DIFF
--- a/meta-polarfire-soc-bsp/recipes-core/images/mpfs-dev-cli.bb
+++ b/meta-polarfire-soc-bsp/recipes-core/images/mpfs-dev-cli.bb
@@ -74,6 +74,7 @@ IMAGE_INSTALL = "\
     dtc \
     cmake \
     kernel-modules kernel-dev \
+    ethtool \
+    iperf3 \
     ${CORE_IMAGE_EXTRA_INSTALL} \
     "
-

--- a/meta-polarfire-soc-bsp/recipes-kernel/linux/files/icicle-kit/mpfs_cmdline.cfg
+++ b/meta-polarfire-soc-bsp/recipes-kernel/linux/files/icicle-kit/mpfs_cmdline.cfg
@@ -1,2 +1,2 @@
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="earlycon=sbi root=/dev/mmcblk0p3 rootwait uio_pdrv_genirq.of_id=generic-uio"
+CONFIG_CMDLINE="earlycon=sbi root=/dev/mmcblk0p3 rootwait uio_pdrv_genirq.of_id=generic-uio clk_ignore_unused"

--- a/meta-polarfire-soc-bsp/recipes-kernel/linux/mpfs-linux.bb
+++ b/meta-polarfire-soc-bsp/recipes-kernel/linux/mpfs-linux.bb
@@ -42,3 +42,6 @@ do_deploy:append() {
 
 addtask deploy after do_install
 
+KERNEL_FEATURES:append = " \
+    CONFIG_NET_RX_BUSY_POLL=y \
+"


### PR DESCRIPTION
Related to polarfire-soc/polarfire-soc-documentation#596

Add `clk_ignore_unused` to the `CONFIG_CMDLINE` parameter in `mpfs_cmdline.cfg` and `mpfs_amp_cmdline.cfg` to prevent unused clocks from being disabled.

Add `ethtool` and `iperf3` to the `IMAGE_INSTALL` list in `mpfs-dev-cli.bb` to enable network interface configuration and network performance testing.

Add `CONFIG_NET_RX_BUSY_POLL=y` to the kernel configuration in `mpfs-linux.bb` to enable busy polling for network receive.
